### PR TITLE
saner bash variable names, optional 'debug' mode

### DIFF
--- a/serverFilesCourse/r_autograder/pltest.R
+++ b/serverFilesCourse/r_autograder/pltest.R
@@ -1,6 +1,6 @@
 ## Simple-yet-good enough runner for R questions
 ##
-## Alton Barbehenn and Dirk Eddelbuettel, Aug/Sep 2019
+## Alton Barbehenn and Dirk Eddelbuettel, 2019 - 2021
 
 result <- tryCatch({
 
@@ -15,7 +15,8 @@ result <- tryCatch({
 
     ## Run tests in the test directory
     cat("[pltest] about to call tests from", getwd(), "\n")
-    test_results <- as.data.frame(tinytest::run_test_dir(tests_dir, verbose = FALSE))
+    test_results <- as.data.frame(tinytest::run_test_dir(tests_dir,
+                                                         verbose = Sys.getenv("DEBUG", "off") == "on"))
 
     ## Aggregate test results and process NAs as some question may have exited
     res <- merge(test_results, question_details, by = "file", all = TRUE)

--- a/serverFilesCourse/r_autograder/run.sh
+++ b/serverFilesCourse/r_autograder/run.sh
@@ -5,7 +5,8 @@
 ##########################
 
 ## switch to control if more values are displayed on console or not
-DEBUG="off"
+DEBUG="on"
+export DEBUG
 if [ ${DEBUG} == "on" ]; then VFLAG="-v" else VFLAG=""; fi
 
 ## the directory where the file pertaining to the job are mounted
@@ -42,7 +43,7 @@ cp    ${VFLAG}  ${AG_DIR}/*       ${MERGE_DIR}
 cp -r ${VFLAG}  ${TEST_DIR}/*     ${MERGE_DIR}
 chown ${VFLAG}  ag:ag             ${MERGE_DIR}
 
-if [ ${DEBUG} == "on" ]; then ls -ld ${MERGE_DIR} ${MERGE_DIR}/* ${MERGE_DIR}/tests; fi
+if [ ${DEBUG} == "on" ]; then ls -ld ${MERGE_DIR} ${MERGE_DIR}/*; fi
 
 
 ##########################

--- a/serverFilesCourse/r_autograder/run.sh
+++ b/serverFilesCourse/r_autograder/run.sh
@@ -4,21 +4,25 @@
 # INIT
 ##########################
 
+## switch to control if more values are displayed on console or not
+DEBUG="off"
+if [ ${DEBUG} == "on" ]; then VFLAG="-v" else VFLAG=""; fi
+
 ## the directory where the file pertaining to the job are mounted
-JOB_DIR="/grade/"
+JOB_DIR="/grade"
 ## the other directories inside it
-STUDENT_DIR="${JOB_DIR}student/"
-AG_DIR="${JOB_DIR}serverFilesCourse/r_autograder/"
-TEST_DIR="${JOB_DIR}tests/"
-OUT_DIR="${JOB_DIR}results/"
+STUDENT_DIR="${JOB_DIR}/student"
+AG_DIR="${JOB_DIR}/serverFilesCourse/r_autograder"
+TEST_DIR="${JOB_DIR}/tests"
+OUT_DIR="${JOB_DIR}/results"
 
 ## where we will copy everything
-MERGE_DIR="${JOB_DIR}run/"
+MERGE_DIR="${JOB_DIR}/run"
 ## where we will put the actual student code - this depends on what the autograder expects, etc
-BIN_DIR="${MERGE_DIR}bin/"
+BIN_DIR="${MERGE_DIR}/bin"
 
 ## now set up the stuff so that our run.sh can work
-echo "[init] making directories"
+echo "[run.sh] making directories"
 mkdir ${MERGE_DIR} ${BIN_DIR} ${OUT_DIR}
 
 ## making the test directory root:root and stripping group and others
@@ -28,17 +32,17 @@ chmod -R go-rwx    ${TEST_DIR}
 
 ## under 'tinytest' artefacts are created where the tests are running
 ## so let the 'ag' user own the directory to write files, run mkdir, ...
-echo "[init] setting up tests directory for 'ag' user"
+echo "[run.sh] setting up tests directory for 'ag' user"
 chown ag:ag ${TEST_DIR}
-#ls -ld ${TEST_DIR}tests
+if [ ${DEBUG} == "on" ]; then ls -ld ${TEST_DIR}; fi
 
-echo "[init] copying content"
-cp    ${STUDENT_DIR}* ${BIN_DIR}
-cp    ${AG_DIR}*      ${MERGE_DIR}
-cp -r ${TEST_DIR}*    ${MERGE_DIR}
-chown ag:ag           ${MERGE_DIR}
+echo "[run.sh] copying content"
+cp    ${VFLAG}  ${STUDENT_DIR}/*  ${BIN_DIR}
+cp    ${VFLAG}  ${AG_DIR}/*       ${MERGE_DIR}
+cp -r ${VFLAG}  ${TEST_DIR}/*     ${MERGE_DIR}
+chown ${VFLAG}  ag:ag             ${MERGE_DIR}
 
-#ls -ld ${MERGE_DIR} ${MERGE_DIR}* ${MERGE_DIR}tests/*
+if [ ${DEBUG} == "on" ]; then ls -ld ${MERGE_DIR} ${MERGE_DIR}/* ${MERGE_DIR}/tests; fi
 
 
 ##########################
@@ -47,21 +51,22 @@ chown ag:ag           ${MERGE_DIR}
 
 cd ${MERGE_DIR}
 
-echo "[run] starting autograder"
+echo "[run.sh] starting autograder"
 
 ## we evaluate student code inside the test functions as a limited user called ag
 ## see the R package plr in the stat430dspm repo for details of the implementation
-echo "[run] Rscript pltest.R"
+echo "[run.sh] Rscript pltest.R"
 Rscript pltest.R
 
 if [ ! -s results.json ]
 then
-  # Let's attempt to keep everything from dying completely
-  echo '{"succeeded": false, "score": 0.0, "message": "Catastrophic failure! Contact course staff and have them check the logs for this submission."}' > results.json
+    # Let's attempt to keep everything from dying completely
+    echo '{"succeeded": false, "score": 0.0, "message": "Catastrophic failure! Contact course staff and have them check the logs for this submission."}' > results.json
 fi
 
-echo "[run] autograder completed"
+echo "[run.sh] autograder completed"
 
 # get the results from the file
-cp ${MERGE_DIR}/results.json '/grade/results/results.json'
-echo "[run] copied results"
+cp  ${VFLAG}  ${MERGE_DIR}/results.json  ${OUT_DIR}
+echo "[run.sh] copied results and DONE."
+echo "[run.sh] DONE"


### PR DESCRIPTION
This PR makes run.sh a little saner (esp in its use of the slash separating directories), adds a bug toggle, and (derived from it) a verbosity flag.   

In default mode, it looks like 

```sh
Starting PrairieLearn...
info: config.json not found, using default configuration
info: config.json not found, using default configuration
info: Workspace host ready
info: PrairieLearn server ready, press Control-C to quit
info: Go to http://localhost:3000
info: docker pull output:  {"status":"Pulling from stat447/pl","id":"latest"}
info: docker pull output:  {"status":"Digest: sha256:2c399f9c84f3c264ce65996fe8947be70da7add718c9a943dcf38f4fca4cb094"}
info: docker pull output:  {"status":"Status: Image is up to date for stat447/pl:latest"}
info: container> [run.sh] making directories
info: container> [run.sh] setting up tests directory for 'ag' user
info: container> [run.sh] copying content
info: container> [run.sh] starting autograder
info: container> [run.sh] Rscript pltest.R
info: container> [pltest] about to call tests from /grade/run 
info: container> [run.sh] autograder completed
info: container> [run.sh] copied results and DONE.
info: container> [run.sh] DONE
info: Constructing results object
info: parsing!
```

where setting the debug flag (which maybe we could pass into Docker via an env var too, come to think about it -- currently a variable in the script)

```
Starting PrairieLearn...
info: config.json not found, using default configuration
info: config.json not found, using default configuration
info: Workspace host ready
info: docker pull output:  {"status":"Digest: sha256:2c399f9c84f3c264ce65996fe8947be70da7add718c9a943dcf38f4fca4cb094"}
info: docker pull output:  {"status":"Status: Image is up to date for stat447/pl:latest"}
info: container> [run.sh] making directories
info: container> [run.sh] setting up tests directory for 'ag' user
info: container> drwx------ 2 ag ag 4096 Aug 29 13:35 /grade/tests
info: container> [run.sh] copying content
info: container> '/grade/student/student.R' -> '/grade/run/bin/student.R'
info: container> '/grade/serverFilesCourse/r_autograder/pltest.R' -> '/grade/run/pltest.R'
info: container> '/grade/serverFilesCourse/r_autograder/run.sh' -> '/grade/run/run.sh'
info: container> '/grade/tests/ans.R' -> '/grade/run/ans.R'
info: container> '/grade/tests/test_01_exists.R' -> '/grade/run/test_01_exists.R'
info: container> '/grade/tests/test_02_type.R' -> '/grade/run/test_02_type.R'
info: container> '/grade/tests/test_03_length.R' -> '/grade/run/test_03_length.R'
info: container> '/grade/tests/test_04_components_exist.R' -> '/grade/run/test_04_components_exist.R'
info: container> '/grade/tests/test_05_types.R' -> '/grade/run/test_05_types.R'
info: container> '/grade/tests/test_06_correct_components.R' -> '/grade/run/test_06_correct_components.R'
info: container> changed ownership of '/grade/run' from root:root to ag:ag
info: container> drwxr-xr-x 3 ag   ag   4096 Aug 29 13:35 /grade/run
info: container> -rw------- 1 root root  121 Aug 29 13:35 /grade/run/ans.R
info: container> drwxr-xr-x 2 root root 4096 Aug 29 13:35 /grade/run/bin
info: container> -rw-r--r-- 1 root root 1697 Aug 29 13:35 /grade/run/pltest.R
info: container> -rwxr-xr-x 1 root root 2293 Aug 29 13:35 /grade/run/run.sh
info: container> -rw------- 1 root root  461 Aug 29 13:35 /grade/run/test_01_exists.R
info: container> -rw------- 1 root root  705 Aug 29 13:35 /grade/run/test_02_type.R
info: container> -rw------- 1 root root  480 Aug 29 13:35 /grade/run/test_03_length.R
info: container> -rw------- 1 root root  627 Aug 29 13:35 /grade/run/test_04_components_exist.R
info: container> -rw------- 1 root root  738 Aug 29 13:35 /grade/run/test_05_types.R
info: container> -rw------- 1 root root  690 Aug 29 13:35 /grade/run/test_06_correct_components.R
info: container> [run.sh] starting autograder
info: container> [run.sh] Rscript pltest.R
info: container> [pltest] about to call tests from /grade/run 
info: container> [run.sh] autograder completed
info: container> '/grade/run/results.json' -> '/grade/results/results.json'
info: container> [run.sh] copied results and DONE.
info: container> [run.sh] DONE
info: Constructing results object
```